### PR TITLE
Resolve merge markers in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,6 @@
 version = 1
 revision = 2
 requires-python = ">=3.10"
-<<<<<<< HEAD
-=======
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -1196,14 +1194,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e7/e12f2d9b0a2c4a2cc86e2aabff7ccfd24f03e597d770abfa2acd313ee46b/pandas-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e1991bbb96f4050b09b5f811253c4f3cf05ee89a589379aa36cd623f21a31d6f", size = 12547686, upload-time = "2025-06-06T00:00:26.142Z" },
     { url = "https://files.pythonhosted.org/packages/39/c2/646d2e93e0af70f4e5359d870a63584dacbc324b54d73e6b3267920ff117/pandas-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:bb3be958022198531eb7ec2008cfc78c5b1eed51af8600c6c5d9160d89d8d249", size = 13231847, upload-time = "2025-06-05T03:27:51.465Z" },
 ]
->>>>>>> feat/pdf-to-epub-pipeline
 
 [[package]]
 name = "pdftoepub"
 version = "0.1.0"
 source = { virtual = "." }
-<<<<<<< HEAD
-=======
 dependencies = [
     { name = "docling" },
     { name = "ebooklib" },
@@ -2426,4 +2421,3 @@ sdist = { url = "https://files.pythonhosted.org/packages/a7/d1/e026d33dd5d552e5b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/b1/a252d499f2760b314fcf264d2b36fcc4343a1ecdb25492b210cb0db70a68/XlsxWriter-3.2.3-py3-none-any.whl", hash = "sha256:593f8296e8a91790c6d0378ab08b064f34a642b3feb787cf6738236bd0a4860d", size = 169433, upload-time = "2025-04-17T10:11:21.329Z" },
 ]
->>>>>>> feat/pdf-to-epub-pipeline


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers in `uv.lock`

## Testing
- `python -m py_compile pdf_to_epub.py`

------
https://chatgpt.com/codex/tasks/task_e_68439884dd7c83249a391e4ad5a5ed18